### PR TITLE
Add separate provider alias and use in resources

### DIFF
--- a/components/dcr/data.tf
+++ b/components/dcr/data.tf
@@ -1,8 +1,10 @@
 data "azurerm_resource_group" "log_analytics_rg" {
-  name = "oms-automation"
+  provider = azurerm.log_analytics
+  name     = "oms-automation"
 }
 
 data "azurerm_log_analytics_workspace" "workspace" {
+  provider            = azurerm.log_analytics
   name                = local.log_analytics_workspace
   resource_group_name = data.azurerm_resource_group.log_analytics_rg.name
 }

--- a/components/dcr/data_collection_rule.tf
+++ b/components/dcr/data_collection_rule.tf
@@ -1,4 +1,5 @@
 resource "azurerm_monitor_data_collection_rule" "windows_data_collection_rule" {
+  provider            = azurerm.log_analytics
   name                = "ama-windows-vm-logs"
   resource_group_name = data.azurerm_log_analytics_workspace.workspace.resource_group_name
   location            = var.location
@@ -39,6 +40,7 @@ resource "azurerm_monitor_data_collection_rule" "windows_data_collection_rule" {
 }
 
 resource "azurerm_monitor_data_collection_rule" "linux_data_collection_rule" {
+  provider            = azurerm.log_analytics
   name                = "ama-linux-vm-logs"
   resource_group_name = data.azurerm_log_analytics_workspace.workspace.resource_group_name
   location            = var.location

--- a/components/dcr/providers.tf
+++ b/components/dcr/providers.tf
@@ -11,5 +11,11 @@ terraform {
 
 provider "azurerm" {
   features {}
+}
+
+provider "azurerm" {
+  alias = "log_analytics"
+  features {}
   subscription_id = var.log_analytics_sub_id
+
 }


### PR DESCRIPTION
### Jira link

### Change description
- Added a new provider config under alias `log_analytics`
- Trying to fix issue with tf state not saving correctly. Terraform init looks to be running with wrong subscription_id e.g. `-backend-config=subscription_id=8999dec3-0104-4a27-94ee-6588559729d1` instead of `-backend-config=subscription_id=04d27a32-7a07-48b3-95b8-3c8691e1a263`
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
